### PR TITLE
fix: set gzip headers only after response body is compressed

### DIFF
--- a/srv_middleware.go
+++ b/srv_middleware.go
@@ -77,9 +77,10 @@ func (g *gzipSrvMiddleware) SrvMiddleware(ctx context.Context, c *app.RequestCon
 
 	c.Next(ctx)
 
-	c.Header("Content-Encoding", "gzip")
-	c.Header("Vary", "Accept-Encoding")
 	if len(c.Response.Body()) > 0 {
+		c.Header("Content-Encoding", "gzip")
+		c.Header("Vary", "Accept-Encoding")
+		
 		gzipBytes := compress.AppendGzipBytesLevel(nil, c.Response.Body(), g.level)
 		c.Response.SetBodyStream(bytes.NewBuffer(gzipBytes), len(gzipBytes))
 	}


### PR DESCRIPTION
#### What type of PR is this?

fix: set gzip headers only after response body is compressed

#### What this PR does / why we need it (English/Chinese):

修复在使用hertz系统默认的404响应体时，未执行压缩但返回了gzip头域问题

#### Which issue(s) this PR fixes:

#24 
